### PR TITLE
mention osmosis/osmconvert in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ NOTE
 
 This package requires shapely v2.0 or later. Installing this package in an existing environment might overwrite older versions. 
 
+
+The (optional) clipping functionalities require manual installation of osmconvert or osmosis. See tutorial 1 for details.
+
 ---
 
 ## Example


### PR DESCRIPTION
should be mentioned in readmen that the clipping functionalities need another command-line tool which has to be installed manually.